### PR TITLE
Fixed retry behavior, until-successful implemented

### DIFF
--- a/src/main/mule/sources/anypoint/platform/apis/api-call-analytics.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-analytics.xml
@@ -8,11 +8,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 
 	<flow name="api-call-analytics-events-flow" doc:id="cb45e4dc-7fd3-476d-aff3-7c0a30556088" maxConcurrency="${anypoint.platform.apis.analytics.maxConcurrency}">
 		<logger level="DEBUG" doc:name="Logger" doc:id="c04d063d-9f26-41c8-9f2c-efd64bc5a457" message="Calling Analytics - Events" />
-		<flow-ref doc:name="Get Events Flow Reference" doc:id="61c06a57-895a-4101-8404-a9a3c0d8ae69" name="api-call-analytics-get-events-flow" />
-		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["Analytics - Events, Response Status Code:" ++ attributes.statusCode]' />
-	</flow>
-	<flow name="api-call-analytics-get-events-flow" doc:id="7bbe4fb0-475f-44ac-821f-21bccc72768a" >
-		<http:request method="GET" doc:name="Get Events Request" doc:id="ea3a4010-08c1-44e9-b9d4-a82201dbb162" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.analytics.events.path}">
+		<until-successful maxRetries="${anypoint.platform.apis.analytics.retries.max}" doc:name="Until Successful" doc:id="4b40f21c-af94-4f31-b8ad-242148a47034" millisBetweenRetries="${anypoint.platform.apis.analytics.retries.wait}">
+			<http:request method="GET" doc:name="Get Events Request" doc:id="ea3a4010-08c1-44e9-b9d4-a82201dbb162" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.analytics.events.path}">
 			<http:headers><![CDATA[#[output application/java
 ---
 {
@@ -32,28 +29,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	"format" : p('anypoint.platform.apis.analytics.events.format')
 }]]]></http:query-params>
 		</http:request>
-		<error-handler >
-			<on-error-continue enableNotifications="false" logException="false" doc:name="On HTTP 429 Error" doc:id="15d90329-25e5-4fcc-b2f9-931da8f02b58" type="HTTP:TIMEOUT,HTTP:INTERNAL_SERVER_ERROR,HTTP:TOO_MANY_REQUESTS">
-				<set-variable value="#[vars.pendingRetries default (p('anypoint.platform.apis.analytics.retries.max') as Number)]" doc:name="Set pendingRetries" doc:id="5c1f3d03-a954-471c-969d-969b877a48c5" variableName="pendingRetries"/>
-				<choice doc:name="Choice" doc:id="48026431-9648-4735-9620-263244523189" >
-					<when expression="#[vars.pendingRetries &gt; 0]">
-						<ee:transform doc:name="Wait" doc:id="2a5ba013-0fbe-4364-a0dd-28c983fbdbea">
-							<ee:message>
-								<ee:set-payload><![CDATA[payload dw::Runtime::wait (p('anypoint.platform.apis.analytics.retries.wait') as Number)]]></ee:set-payload>
-							</ee:message>
-							<ee:variables >
-								<ee:set-variable variableName="pendingRetries" ><![CDATA[vars.pendingRetries - 1]]></ee:set-variable>
-							</ee:variables>
-						</ee:transform>
-						<flow-ref doc:name="Get Events Flow Reference" doc:id="1de62a92-b7d7-4752-a3d7-c8e595efd12e" name="api-call-analytics-get-events-flow" />
-					</when>
-					<otherwise >
-						<raise-error doc:name="Raise error" doc:id="dcc4040f-12f0-4c6f-9644-32cf13a4da84" type="APP:RETRIES_EXHAUSTED" description="Exchange - Get Assets - Retries were exhausted"/>
-					</otherwise>
-				</choice>
-				<remove-variable doc:name="Remove pendingRetries" doc:id="1fa7fcd9-007b-4e01-a7b1-67314c5ef904" variableName="pendingRetries"/>
-			</on-error-continue>
-		</error-handler>
+		</until-successful>
+		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["Analytics - Events, Response Status Code:" ++ attributes.statusCode]' />
 	</flow>
 	<flow name="api-call-analytics-query-flow" doc:id="9b3e1b21-cf25-4acf-b543-6539891fa08c" maxConcurrency="${anypoint.platform.apis.analytics.maxConcurrency}">
 		<logger level="DEBUG" doc:name="Logger" doc:id="aeda6f47-6889-471c-9163-296ed1791eab" message="Calling Analytics - Query" />
@@ -62,11 +39,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 				<ee:set-payload resource="dw/anypoint/analytics-query-request.dwl" />
 			</ee:message>
 		</ee:transform>
-		<flow-ref doc:name="Get Enriched Data Flow Reference" doc:id="923a0942-3fa6-40c1-bac9-085a9f7d0da9" name="api-call-analytics-get-enriched-data-flow" />
-		<logger level="DEBUG" doc:name="Logger" doc:id="6b27bd5e-27be-4376-84da-31f328fc8b98" message='#["Analytics - Query, Response Status Code:" ++ attributes.statusCode]' />
-	</flow>
-	<flow name="api-call-analytics-get-enriched-data-flow" doc:id="b409a23e-16e0-4e29-bcc5-947d37a6f158" >
-		<http:request method="POST" doc:name="Get Analytics Enriched Data Request" doc:id="2021c5c3-4242-4cc9-8a29-bad19ce7af3d" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.analytics.query.path}" responseTimeout="${anypoint.platform.apis.analytics.query.timeout}">
+		<until-successful maxRetries="${anypoint.platform.apis.analytics.retries.max}" doc:name="Until Successful" doc:id="b185c1d4-2e43-4926-831c-ce7610ae1193" millisBetweenRetries="${anypoint.platform.apis.analytics.retries.wait}">
+			<http:request method="POST" doc:name="Get Analytics Enriched Data Request" doc:id="2021c5c3-4242-4cc9-8a29-bad19ce7af3d" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.analytics.query.path}" responseTimeout="${anypoint.platform.apis.analytics.query.timeout}">
 			<http:headers><![CDATA[#[output application/java
 ---
 {
@@ -79,28 +53,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	"envId" : vars.environmentId
 }]]]></http:uri-params>
 		</http:request>
-		<error-handler >
-			<on-error-continue enableNotifications="false" logException="false" doc:name="On HTTP 429 Error" doc:id="fb4af52a-c1f2-420c-abcc-d8e3332bafd0" type="HTTP:TIMEOUT,HTTP:INTERNAL_SERVER_ERROR,HTTP:TOO_MANY_REQUESTS">
-				<set-variable value="#[vars.pendingRetries default (p('anypoint.platform.apis.analytics.retries.max') as Number)]" doc:name="Set pendingRetries" doc:id="4a2895c6-ceeb-4e7f-9776-04eaa3cbb8ad" variableName="pendingRetries"/>
-				<choice doc:name="Choice" doc:id="04e65d5a-231a-4568-a4da-2481cfc326d8" >
-					<when expression="#[vars.pendingRetries &gt; 0]">
-						<ee:transform doc:name="Wait" doc:id="b9c78702-dceb-4b7a-a574-e1b2c2c31c45">
-							<ee:message>
-								<ee:set-payload><![CDATA[payload dw::Runtime::wait (p('anypoint.platform.apis.analytics.retries.wait') as Number)]]></ee:set-payload>
-							</ee:message>
-							<ee:variables >
-								<ee:set-variable variableName="pendingRetries" ><![CDATA[vars.pendingRetries - 1]]></ee:set-variable>
-							</ee:variables>
-						</ee:transform>
-						<flow-ref doc:name="Get Enriched Data Flow Reference" doc:id="f386de0d-4976-418b-9f8f-d73dc9f55140" name="api-call-analytics-get-enriched-data-flow" />
-					</when>
-					<otherwise >
-						<raise-error doc:name="Raise error" doc:id="7333d3d3-660d-4730-968e-b67db8de2d66" type="APP:RETRIES_EXHAUSTED" description="Exchange - Get Assets - Retries were exhausted"/>
-					</otherwise>
-				</choice>
-				<remove-variable doc:name="Remove pendingRetries" doc:id="2851f161-602e-405d-a21c-f36312465250" variableName="pendingRetries"/>
-			</on-error-continue>
-		</error-handler>
+		</until-successful>
+		<logger level="DEBUG" doc:name="Logger" doc:id="6b27bd5e-27be-4376-84da-31f328fc8b98" message='#["Analytics - Query, Response Status Code:" ++ attributes.statusCode]' />
 	</flow>
 
 </mule>

--- a/src/main/mule/sources/anypoint/platform/apis/api-call-api-manager.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-api-manager.xml
@@ -27,11 +27,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	
 	<flow name="api-call-api-manager-api-policies-flow" doc:id="392b0852-86a0-4067-bab6-7b5f55855136" maxConcurrency="${anypoint.platform.apis.apiManager.maxConcurrency}">
 		<logger level="DEBUG" doc:name="Logger" doc:id="19b1b41d-e3f3-40bf-a39d-2fbdfc8e2738" message="Calling API Manager - API Policies" />
-		<flow-ref doc:name="Get API Policies Flow Reference" doc:id="68f786bc-35e9-4cfd-82a0-2f381a69e1a9" name="api-call-api-manager-get-api-policies-flow"/>
-		<logger level="DEBUG" doc:name="Logger" doc:id="3099c073-7970-440a-8683-90ecfe96a6d5" message='#["API Manager - API Policies, Response Status Code:" ++ attributes.statusCode]' />
-	</flow>
-	<flow name="api-call-api-manager-get-api-policies-flow" doc:id="b713ffb3-75f8-4b8e-a235-727f9cedd21c" >
-		<http:request method="GET" doc:name="Get API Policies Request" doc:id="d5c85809-9166-498c-babc-e74cd8a8a886" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.apiManager.apiPolicies.path}">
+		<until-successful maxRetries="${anypoint.platform.apis.apiManager.apiPolicies.retries.max}" doc:name="Until Successful" doc:id="bb0f3611-9f0e-43bb-bbc9-efb617ca214e" millisBetweenRetries="${anypoint.platform.apis.apiManager.apiPolicies.retries.wait}">
+			<http:request method="GET" doc:name="Get API Policies Request" doc:id="d5c85809-9166-498c-babc-e74cd8a8a886" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.apiManager.apiPolicies.path}">
 			<http:headers><![CDATA[#[output application/java
 ---
 {
@@ -52,28 +49,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 	"includeValidation" : true
 }]]]></http:query-params>
 		</http:request>
-		<error-handler >
-			<on-error-continue enableNotifications="false" logException="false" doc:name="On HTTP 429/500 Error" doc:id="3cba3d91-87a8-46d1-a51c-4fec21a6637b" type="HTTP:INTERNAL_SERVER_ERROR,HTTP:TOO_MANY_REQUESTS">
-				<set-variable value="#[vars.pendingRetries default (p('anypoint.platform.apis.apiManager.apiPolicies.retries.max') as Number)]" doc:name="Set pendingRetries" doc:id="9310a5c4-eebd-4316-b500-f40fd0c1c066" variableName="pendingRetries"/>
-				<choice doc:name="Choice" doc:id="e2f9d666-453c-47b6-b062-e8e51ff01310" >
-					<when expression="#[vars.pendingRetries &gt; 0]">
-						<ee:transform doc:name="Wait" doc:id="8aa782e9-31f7-4295-b75c-784320844a79">
-							<ee:message>
-								<ee:set-payload><![CDATA[payload dw::Runtime::wait (p('anypoint.platform.apis.apiManager.apiPolicies.retries.wait') as Number)]]></ee:set-payload>
-							</ee:message>
-							<ee:variables >
-								<ee:set-variable variableName="pendingRetries" ><![CDATA[vars.pendingRetries - 1]]></ee:set-variable>
-							</ee:variables>
-						</ee:transform>
-						<flow-ref doc:name="Get API Policies Flow Reference" doc:id="1fad8a3e-09f3-4768-a2b7-7147ea57cf12" name="api-call-api-manager-get-api-policies-flow" />
-					</when>
-					<otherwise >
-						<raise-error doc:name="Raise error" doc:id="f2b6fcb3-3368-4b57-8006-f1ffc1d69e39" type="APP:RETRIES_EXHAUSTED" description="Exchange - Get Assets - Retries were exhausted"/>
-					</otherwise>
-				</choice>
-				<remove-variable doc:name="Remove pendingRetries" doc:id="450af0cc-0853-4f53-b753-c0964fc7ab64" variableName="pendingRetries"/>
-			</on-error-continue>
-		</error-handler>
+		</until-successful>
+		<logger level="DEBUG" doc:name="Logger" doc:id="3099c073-7970-440a-8683-90ecfe96a6d5" message='#["API Manager - API Policies, Response Status Code:" ++ attributes.statusCode]' />
 	</flow>
 	<flow name="api-call-api-manager-automated-policies-flow" doc:id="42654c28-a89d-4de6-88ba-dc0fb72281a8" maxConcurrency="${anypoint.platform.apis.apiManager.maxConcurrency}">
 		<logger level="DEBUG" doc:name="Logger" doc:id="72a5e4e6-06fc-40d8-a9c8-b52535a58743" message="Calling API Manager - Automated Policies" />

--- a/src/main/mule/sources/anypoint/platform/apis/api-call-exchange.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-exchange.xml
@@ -14,12 +14,8 @@ http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mu
 				<ee:set-variable resource="dw/anypoint/anypoint-exchange-build-graphql-query.dwl" variableName="graphqlQuery" />
 			</ee:variables>
 		</ee:transform>
-		<flow-ref doc:name="Get Assets Flow Reference" doc:id="cb890266-e926-4610-abd2-8ae428ca2daf" name="api-call-exchange-get-assets-flow" />
-		<set-payload value="#[output application/java --- payload.data.assets]" doc:name="Set Payload - Data Assets" doc:id="536390ec-0bf3-4f0c-b46c-159bc1e6fd51" />
-		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["Exchange - Assets, Response Status Code:" ++ attributes.statusCode]' />
-	</flow>
-	<flow name="api-call-exchange-get-assets-flow" doc:id="199136de-bf24-4e49-8820-a1692cbd36d1" >
-		<http:request method="POST" doc:name="Get Assets" doc:id="8bc85d2b-02cc-4aa4-b430-5f59fe7ba99c" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.exchange.graphql.path}">
+		<until-successful maxRetries="${anypoint.platform.apis.exchange.retries.max}" doc:name="Until Successful" doc:id="cbf15f26-56e8-4183-bf2a-aa7c30b693a0" millisBetweenRetries="${anypoint.platform.apis.exchange.retries.wait}">
+			<http:request method="POST" doc:name="Get Assets" doc:id="8bc85d2b-02cc-4aa4-b430-5f59fe7ba99c" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.exchange.graphql.path}">
 			<http:body><![CDATA[#[output application/json
 ---
 {
@@ -30,28 +26,9 @@ http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mu
   operationName: "Platform"
 }]]]></http:body>
 		</http:request>
-		<error-handler >
-			<on-error-continue enableNotifications="false" logException="false" doc:name="On HTTP 429 Error" doc:id="de5b31b6-aae6-4103-811c-7b8866f2c2f1" type="HTTP:TOO_MANY_REQUESTS">
-				<set-variable value="#[vars.pendingRetries default (p('anypoint.platform.apis.exchange.retries.max') as Number)]" doc:name="Set pendingRetries" doc:id="de8cb018-672f-4a6a-974e-084ed103caf9" variableName="pendingRetries"/>
-				<choice doc:name="Choice" doc:id="16357cad-1388-4cfd-aaad-bb38ae9e5c86" >
-					<when expression="#[vars.pendingRetries &gt; 0]">
-						<ee:transform doc:name="Wait" doc:id="d5d2c28f-9884-4239-8b34-b95ceeb2c8e9">
-							<ee:message>
-								<ee:set-payload><![CDATA[payload dw::Runtime::wait (p('anypoint.platform.apis.exchange.retries.wait') as Number)]]></ee:set-payload>
-							</ee:message>
-							<ee:variables >
-								<ee:set-variable variableName="pendingRetries" ><![CDATA[vars.pendingRetries - 1]]></ee:set-variable>
-							</ee:variables>
-						</ee:transform>
-						<flow-ref doc:name="Get Assets Flow Reference" doc:id="47b33c77-08a2-4715-8023-73524a993f0a" name="api-call-exchange-get-assets-flow"/>
-					</when>
-					<otherwise >
-						<raise-error doc:name="Raise error" doc:id="1272eaf1-f5e2-49a2-90c1-6fc5bdb616b7" type="APP:RETRIES_EXHAUSTED" description="Exchange - Get Assets - Retries were exhausted"/>
-					</otherwise>
-				</choice>
-				<remove-variable doc:name="Remove pendingRetries" doc:id="6b690080-8332-4368-842f-716602f5d9ec" variableName="pendingRetries"/>
-			</on-error-continue>
-		</error-handler>
+		</until-successful>
+		<set-payload value="#[output application/java --- payload.data.assets]" doc:name="Set Payload - Data Assets" doc:id="536390ec-0bf3-4f0c-b46c-159bc1e6fd51" />
+		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["Exchange - Assets, Response Status Code:" ++ attributes.statusCode]' />
 	</flow>
 	<flow name="api-call-exchange-asset-dependencies-flow" doc:id="8d61d5dd-a6f3-4ca2-ba1a-4b3026de2910" maxConcurrency="${anypoint.platform.apis.exchange.maxConcurrency}">
 		<logger level="DEBUG" doc:name="Logger" doc:id="3e43ad0e-d15b-4fe9-81ab-4535b69d588f" message="Calling Exchange - Asset dependencies" />
@@ -62,12 +39,8 @@ http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mu
 				<ee:set-variable resource="dw/anypoint/anypoint-exchange-build-graphql-dependencies-query.dwl" variableName="graphqlQuery" />
 			</ee:variables>
 		</ee:transform>
-		<flow-ref doc:name="Get Assets Dependencies Flow Reference" doc:id="20a236df-50c5-41f1-8eec-be093a4ad632" name="api-call-exchange-get-assets-dependencies-flow"/>
-		<set-payload value="#[output application/java --- payload.data.asset.dependencies]" doc:name="Set Payload - Data Assets Dependencies" doc:id="51bf83d2-c080-4fb8-9398-e4cee83bc18d" />
-		<logger level="DEBUG" doc:name="Logger" doc:id="6614e1cb-bb54-4e89-b1bb-84630aeae5fa" message='#["Asset dependencies, Response Status Code:" ++ attributes.statusCode]' />
-	</flow>
-	<flow name="api-call-exchange-get-assets-dependencies-flow" doc:id="d45ceb5e-a4e0-4795-8e18-46727f8d3eff" >
-		<http:request method="POST" doc:name="Get Asset Dependencies" doc:id="3ff3648d-aa68-46db-b39a-2b563ce443f3" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.exchange.graphql.path}">
+		<until-successful maxRetries="${anypoint.platform.apis.exchange.retries.max}" doc:name="Until Successful" doc:id="4aed045d-ba0c-42b9-ad39-24196cc8f9bd" millisBetweenRetries="${anypoint.platform.apis.exchange.retries.wait}">
+			<http:request method="POST" doc:name="Get Asset Dependencies" doc:id="3ff3648d-aa68-46db-b39a-2b563ce443f3" config-ref="HTTP_Request_configuration" path="${anypoint.platform.apis.exchange.graphql.path}">
 			<http:body><![CDATA[#[output application/json
 ---
 {
@@ -78,28 +51,9 @@ http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mu
   operationName: "Platform"
 }]]]></http:body>
 		</http:request>
-		<error-handler >
-			<on-error-continue enableNotifications="false" logException="false" doc:name="On HTTP 429 Error" doc:id="62b4c28e-c943-4a7a-be77-044fb34717a7" type="HTTP:TOO_MANY_REQUESTS">
-				<set-variable value="#[vars.pendingRetries default (p('anypoint.platform.apis.exchange.retries.max') as Number)]" doc:name="Set pendingRetries" doc:id="1dd6012d-780a-4375-8bd4-9031c168105b" variableName="pendingRetries"/>
-				<choice doc:name="Choice" doc:id="3b52c565-6b39-4e7d-84bf-6fedafcb7322" >
-					<when expression="#[vars.pendingRetries &gt; 0]">
-						<ee:transform doc:name="Wait" doc:id="45bdae4d-aeaf-4f08-ab13-276201b4672b">
-							<ee:message>
-								<ee:set-payload><![CDATA[payload dw::Runtime::wait (p('anypoint.platform.apis.exchange.retries.wait') as Number)]]></ee:set-payload>
-							</ee:message>
-							<ee:variables >
-								<ee:set-variable variableName="pendingRetries" ><![CDATA[vars.pendingRetries - 1]]></ee:set-variable>
-							</ee:variables>
-						</ee:transform>
-						<flow-ref doc:name="Get Assets Dependencies Flow Reference" doc:id="6e130641-574c-4e41-9351-394f90b807b8" name="api-call-exchange-get-assets-dependencies-flow"/>
-					</when>
-					<otherwise >
-						<raise-error doc:name="Raise error" doc:id="e354318e-605a-4939-88c7-37f6c97e7fe8" type="APP:RETRIES_EXHAUSTED" description="Exchange - Get Assets - Retries were exhausted"/>
-					</otherwise>
-				</choice>
-				<remove-variable doc:name="Remove pendingRetries" doc:id="f7744d60-ef86-4fdc-bf44-827d09083e50" variableName="pendingRetries"/>
-			</on-error-continue>
-		</error-handler>
+		</until-successful>
+		<set-payload value="#[output application/java --- payload.data.asset.dependencies]" doc:name="Set Payload - Data Assets Dependencies" doc:id="51bf83d2-c080-4fb8-9398-e4cee83bc18d" />
+		<logger level="DEBUG" doc:name="Logger" doc:id="6614e1cb-bb54-4e89-b1bb-84630aeae5fa" message='#["Asset dependencies, Response Status Code:" ++ attributes.statusCode]' />
 	</flow>
 
 </mule>


### PR DESCRIPTION
A custom retry behavior was implemented to retry only in case of an HTTP 429 error. The DW Wait function blocks the CPU_INTENSIVE thread.

An Until Successful scope was applied instead.