### PR TITLE
RawData var assignment

### DIFF
--- a/src/main/resources/dw/common/set-raw-data-from-loader-details-payload-var.dwl
+++ b/src/main/resources/dw/common/set-raw-data-from-loader-details-payload-var.dwl
@@ -1,4 +1,4 @@
 %dw 2.0
 output application/java
 ---
-vars.loaderDetails.rawData
+payload.loaderDetails.rawData


### PR DESCRIPTION
Fixed rawData variable assignment: when setting loaderDetails from payload, rawData value was being retrieved from vars context instead of being retrieved from payload. This was causing rawData to be always null even when correctly set in the payload as a property of loaderDetails element.