### PR TITLE
ARM API Max Concurrency

### DIFF
--- a/src/main/resources/properties/app-common.yaml
+++ b/src/main/resources/properties/app-common.yaml
@@ -32,7 +32,7 @@ anypoint:
         apps:
           path: "/cloudhub/api/v2/applications"
       arm:
-        maxConcurrency: "100"
+        maxConcurrency: "3"
         apps:
           path: "/hybrid/api/v1/applications"
         servers:


### PR DESCRIPTION
ARM API call requests were failing with 503 (SERVICE UNAVAILABLE). Reducing ARM API max concurrent calls from 100 to 3 prevents this error to happen.