### PR TITLE
Issue #64

### DIFF
--- a/src/main/mule/loaders/loader-router.xml
+++ b/src/main/mule/loaders/loader-router.xml
@@ -51,7 +51,7 @@
 				<flow-ref doc:name="loader-elk-main-flow" doc:id="c9706c9c-e85e-417c-a87d-90531ee0afda" name="loader-benefits-elk-main-flow"/>
 			</when>			
 			<otherwise >
-				<flow-ref doc:name="loader-default-flow" doc:id="52ba5200-2a44-4e16-83a1-76125f24fef9" name="loader-default-flow"/>
+				<flow-ref doc:name="loader-default-flow" doc:id="52ba5200-2a44-4e16-83a1-76125f24fef9" name="loader-benefits-flow"/>
 			</otherwise>
 		</choice>
 	</flow>


### PR DESCRIPTION
Fixes #64: platform benefits metrics loader default router should call platform benefits metrics default loader flow instead of platform metrics default loader flow.