### PR TITLE
fix to aggregate API manager payload

### DIFF
--- a/src/main/mule/sources/anypoint/platform/apis/api-call-api-manager.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-api-manager.xml
@@ -57,7 +57,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 						<ee:set-variable resource="dw/anypoint/save-aggregated-api-payload-var.dwl" variableName="aggregatedAPIPayload" />
 					</ee:variables>
 				</ee:transform>
-				<set-variable value="#[vars.offset + 100]" doc:name="offset" doc:id="556d0a3f-3cbe-42ee-b5aa-c5dad5f21e10"
+				<set-variable value="#[vars.offset + Mule::p('anypoint.platform.apis.apiManager.apiDefaultOffset')]" doc:name="offset" doc:id="556d0a3f-3cbe-42ee-b5aa-c5dad5f21e10"
 					variableName="offset" />
 				<flow-ref doc:name="Get more apis" doc:id="3431bd02-f793-45a2-92f6-9c4f63b83513" name="api-call-api-manager-apis-flow" />
 			</when>

--- a/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
+++ b/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
@@ -2,5 +2,7 @@
 import * from dw::util::Values
 output application/java
 ---
-if (vars.aggregatedAPIPayload == null) payload
-else (vars.aggregatedAPIPayload update  "assets" with (vars.aggregatedAPIPayload.assets + payload.assets))
+if (aggregatedAPIPayload == null) 
+	payload
+else 
+	(aggregatedAPIPayload update  "assets" with ({([aggregatedAPIPayload.assets,payload.assets])}))

--- a/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
+++ b/src/main/resources/dw/anypoint/save-aggregated-api-payload-var.dwl
@@ -2,7 +2,7 @@
 import * from dw::util::Values
 output application/java
 ---
-if (aggregatedAPIPayload == null) 
+if (vars.aggregatedAPIPayload == null) 
 	payload
 else 
-	(aggregatedAPIPayload update  "assets" with ({([aggregatedAPIPayload.assets,payload.assets])}))
+	(vars.aggregatedAPIPayload update  "assets" with ({([vars.aggregatedAPIPayload.assets,payload.assets])}))

--- a/src/main/resources/properties/app-common.yaml
+++ b/src/main/resources/properties/app-common.yaml
@@ -61,6 +61,7 @@ anypoint:
             wait: "5000"
         automatedPolicies:
           path: "/apimanager/api/v1/organizations/{orgId}/automated-policies"
+        apiDefaultOffset: "100"
       apiPlatform:
         maxConcurrency: "100"
         clients:


### PR DESCRIPTION
...when # of contracts is greater than the value defined in vars.apisTotalObtained. This fix uses the object destructor notation {([ ])} for object concatenation instead of the typical "++" in order to save some memory footprint.

Additionally, API Manager API offset was externalized to avoid hardcoding.

MUnit tests after changes:
![image](https://user-images.githubusercontent.com/50634447/126509432-8f648026-9c52-4785-8dcd-a88ac3a3d050.png)
