### PR TITLE
Separated Auth and Anypoint Headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,19 +15,20 @@
 
 		<app.runtime>4.3.0</app.runtime>
 		<mule.maven.plugin.version>3.4.1</mule.maven.plugin.version>
-		<munit.version>2.3.1</munit.version>
+		<munit.version>2.3.5</munit.version>
 		<!-- Dependencies versions -->
 		<secure-properties.version>1.2.3</secure-properties.version>
-		<apikit.version>1.4.0</apikit.version>
-		<http.version>1.5.23</http.version>
+		<apikit.version>1.5.3</apikit.version>
+		<http.version>1.5.25</http.version>
 		<sockets.version>1.2.1</sockets.version>
-		<os.version>1.1.6</os.version>
+		<os.version>1.2.1</os.version>
 		<metrics-extension.version>2.2.0</metrics-extension.version>
 		<file.version>1.3.4</file.version>
-		<munit-runner.version>2.3.1</munit-runner.version>
-		<munit-tools.version>2.3.1</munit-tools.version>
+
 		<mule-mongodb-connector.version>6.3.1</mule-mongodb-connector.version>
 		<mongodb-driver-legacy.version>4.0.4</mongodb-driver-legacy.version>
+		<validation.module.version>1.4.5</validation.module.version>
+
 	</properties>
 
 	<build>
@@ -65,7 +66,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<runtimeVersion>${munit.runtime}</runtimeVersion>
+					<runtimeVersion>${app.runtime}</runtimeVersion>
 					<coverage>
 						<runCoverage>true</runCoverage>
 						<formats>
@@ -139,14 +140,14 @@
 		<dependency>
 			<groupId>com.mulesoft.munit</groupId>
 			<artifactId>munit-runner</artifactId>
-			<version>${munit-runner.version}</version>
+			<version>${munit.version}</version>
 			<classifier>mule-plugin</classifier>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.mulesoft.munit</groupId>
 			<artifactId>munit-tools</artifactId>
-			<version>${munit-tools.version}</version>
+			<version>${munit.version}</version>
 			<classifier>mule-plugin</classifier>
 			<scope>test</scope>
 		</dependency>
@@ -170,6 +171,12 @@
 			<version>${mongodb-driver-legacy.version}</version>
 		</dependency>
 		 -->
+		<dependency>
+			<groupId>org.mule.modules</groupId>
+			<artifactId>mule-validation-module</artifactId>
+			<version>${validation.module.version}</version>
+			<classifier>mule-plugin</classifier>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/mule/api.xml
+++ b/src/main/mule/api.xml
@@ -1,16 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <mule xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:apikit="http://www.mulesoft.org/schema/mule/mule-apikit" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation" xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns:http="http://www.mulesoft.org/schema/mule/http" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd http://www.mulesoft.org/schema/mule/http http://www.mulesoft.org/schema/mule/http/current/mule-http.xsd http://www.mulesoft.org/schema/mule/mule-apikit http://www.mulesoft.org/schema/mule/mule-apikit/current/mule-apikit.xsd  http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
     <apikit:config name="api-config" api="api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" raml="api.raml" />
-    <flow name="web-main" doc:id="21dfe96e-4a3e-4810-8a77-9a84600f1a4b" >
-		<http:listener doc:name="Listener" doc:id="a7a27ecf-5e78-414d-a4ff-9b8680b1bac1" config-ref="HTTP_Listener_config" path="/*"/>
-		<choice doc:name="Choice" doc:id="e720d2e4-713c-4ee1-8f5d-6180e02af532" >
-			<when expression="#[p('embedded.dashboard.enabled')]">
-				<http:load-static-resource doc:name="Load static resource" doc:id="7aae6e23-0946-4fd6-a4ce-8459f9f08885" resourceBasePath="${mule.home}/apps/${app.name}/web/" />
-			</when>
-		</choice>
-	</flow>
-	<flow name="api-main">
-        <http:listener config-ref="HTTP_Listener_config" path="/api/*">
+    <flow name="web-main" doc:id="21dfe96e-4a3e-4810-8a77-9a84600f1a4b">
+        <http:listener doc:name="Listener" doc:id="a7a27ecf-5e78-414d-a4ff-9b8680b1bac1" config-ref="HTTP_Listener_config" path="${embedded.dashboard.path}" />
+        <choice doc:name="Choice" doc:id="e720d2e4-713c-4ee1-8f5d-6180e02af532">
+            <when expression="#[p('embedded.dashboard.enabled')]">
+				<logger level="DEBUG" doc:name="Web UI enabled" doc:id="2e80ee6c-b267-4464-bac3-b82cc4aa7622" message="Web UI enabled; providing static resources"/>
+                <http:load-static-resource doc:name="Load static resource" doc:id="7aae6e23-0946-4fd6-a4ce-8459f9f08885" resourceBasePath="${mule.home}/apps/${app.name}/web/" />
+            </when>
+			<otherwise >
+				<logger level="DEBUG" doc:name="Web UI disabled" doc:id="f92de18d-3b3e-4086-b624-6076b9e8ba96" message="Web UI is disabled, so return NOT IMPLEMENTED"/>
+				<ee:transform doc:name="Set 501 - Not Implemented" doc:id="ee410da7-4012-4b35-a4ba-fe224ee4e23e" >
+					<ee:message >
+						<ee:set-payload resource="dw/apikit/error-not-implemented.dwl" />
+					</ee:message>
+					<ee:variables >
+						<ee:set-variable variableName="httpStatus" ><![CDATA[%dw 2.0
+output application/java
+---
+501 as Number]]></ee:set-variable>
+					</ee:variables>
+				</ee:transform>
+			</otherwise>
+        </choice>
+    </flow>
+    <flow name="api-main">
+        <http:listener config-ref="HTTP_Listener_config" path="${api.path}">
             <http:response statusCode="#[vars.httpStatus default 200]" />
             <http:error-response statusCode="#[vars.httpStatus default 500]">
                 <http:body><![CDATA[#[payload]]]></http:body>
@@ -18,7 +33,7 @@
         </http:listener>
         <apikit:router config-ref="api-config" />
         <error-handler>
-            <on-error-propagate type="APIKIT:BAD_REQUEST">
+            <on-error-propagate type="APIKIT:BAD_REQUEST,VALIDATION:INVALID_BOOLEAN" enableNotifications="true" logException="true">
                 <ee:transform xsi:schemaLocation="http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd" doc:id="f0eda6c8-1ae6-4505-9698-2d34fb4de78a">
                     <ee:message>
                         <ee:set-payload resource="dw/apikit/error-bad-request.dwl" />
@@ -116,10 +131,10 @@
     </flow>
     <flow name="get:\platform-metrics:api-config">
         <flow-ref doc:name="Set Auth Vars from Headers Flow Reference" doc:id="a99d508d-5bd1-4627-88d1-fec6fb4ed7cf" name="common-set-auth-vars-from-headers" />
-        <flow-ref doc:name="Set Aggregator Details From Query Params Flow Reference" doc:id="526a1967-37bb-499f-a47d-9c469bb3df26" name="common-set-aggregator-vars-from-query-params"/>
-		<flow-ref doc:name="Aggregator Master Flow Reference" doc:id="5484cc09-2351-49d6-b728-a0d4b0b0d1b9" name="aggregator-platform-metrics-master-flow" />
+        <flow-ref doc:name="Set Aggregator Details From Query Params Flow Reference" doc:id="526a1967-37bb-499f-a47d-9c469bb3df26" name="common-set-aggregator-vars-from-query-params" />
+        <flow-ref doc:name="Aggregator Master Flow Reference" doc:id="5484cc09-2351-49d6-b728-a0d4b0b0d1b9" name="aggregator-platform-metrics-master-flow" />
     </flow>
-    <flow name="post:\platform-metrics\load:api-config">
+    <flow name="post:\platform-metrics\load:application\json:api-config">
         <flow-ref doc:name="Set Auth Vars from Headers Flow Reference" doc:id="e514bd7d-bdbc-4492-844c-b9d4549155f9" name="common-set-auth-vars-from-headers" />
         <flow-ref doc:name="Set Loader Details From Payload Flow Reference" doc:id="e6cdbaa6-d042-4dda-ad53-a9bcb88ee768" name="common-set-loader-vars-from-payload" />
         <flow-ref doc:name="Loader Flow Reference" doc:id="9b9b2d75-6d61-40ce-bc19-518cbb135eb8" name="loader-router-flow" />
@@ -129,7 +144,7 @@
         <flow-ref doc:name="Set Benefits Vars From Query Params Flow Reference" doc:id="4f874701-0491-483f-879e-7fcf9bac5243" name="common-set-benefits-vars-from-query-params" />
         <flow-ref doc:name="Aggregator Platform Benefits Flow Reference" doc:id="ab111296-7f07-480b-b76c-c05de17ae188" name="aggregator-platform-benefits-master-flow" />
     </flow>
-    <flow name="post:\business-metrics\load:api-config">
+    <flow name="post:\business-metrics\load:application\json:api-config">
         <flow-ref doc:name="Set Auth Vars from Headers Flow Reference" doc:id="666ad8cc-9088-4d24-8839-f665a9f9deaa" name="common-set-auth-vars-from-headers" />
         <flow-ref doc:name="Set Loader Details From Payload Flow Reference" doc:id="ad58af15-9a99-49c8-bee5-24d3eb73ee04" name="common-set-loader-vars-from-payload" />
         <flow-ref doc:name="Set Benefits Vars From Payload Flow Reference" doc:id="c3fa4f76-0f14-40cb-9738-1c7011851bfa" name="common-set-benefits-vars-from-payload" />
@@ -137,12 +152,12 @@
     </flow>
     <flow name="get:\sdlc-metrics:api-config">
         <set-variable value="#[attributes.queryParams.raw]" doc:name="Set Raw Data flag" doc:id="a9f8c832-6093-465b-b738-bdea7988b782" variableName="rawData" />
-		<flow-ref doc:name="Set SDLC Details" doc:id="2e0169ea-1652-48ef-89ca-7bc044121f69" name="common-set-sdlc-details"/>
-		<flow-ref doc:name="Aggregator SDLC Flow Reference" doc:id="1dcfab3e-3016-4bed-8234-763027f4760a" name="aggregator-sdlc-metrics-main-flow" />
+        <flow-ref doc:name="Set SDLC Details" doc:id="2e0169ea-1652-48ef-89ca-7bc044121f69" name="common-set-sdlc-details" />
+        <flow-ref doc:name="Aggregator SDLC Flow Reference" doc:id="1dcfab3e-3016-4bed-8234-763027f4760a" name="aggregator-sdlc-metrics-main-flow" />
     </flow>
-    <flow name="post:\sdlc-metrics\load:api-config">
+    <flow name="post:\sdlc-metrics\load:application\json:api-config">
         <flow-ref doc:name="Set Loader Details From Payload Flow Reference" doc:id="5be122d9-d5e8-4059-b082-2eab2c5c4845" name="common-set-loader-vars-from-payload" />
-		<flow-ref doc:name="Set SDLC Details" doc:id="700186a4-a8b4-4fc4-bb36-34f80e0129d1" name="common-set-sdlc-details"/>
-		<flow-ref doc:name="Loader SDLC Flow Reference" doc:id="c84138ab-9d1d-4edf-840e-12d9458584e4" name="loader-sdlc-router-flow" />
+        <flow-ref doc:name="Set SDLC Details" doc:id="700186a4-a8b4-4fc4-bb36-34f80e0129d1" name="common-set-sdlc-details" />
+        <flow-ref doc:name="Loader SDLC Flow Reference" doc:id="c84138ab-9d1d-4edf-840e-12d9458584e4" name="loader-sdlc-router-flow" />
     </flow>
 </mule>

--- a/src/main/mule/common.xml
+++ b/src/main/mule/common.xml
@@ -1,39 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<mule xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core" xmlns="http://www.mulesoft.org/schema/mule/core" xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
-http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd">
- 
-	<flow name="common-set-auth-vars-from-headers" doc:id="49a5f71b-1858-485c-909a-f535468ebfb2">
+<mule
+	xmlns:validation="http://www.mulesoft.org/schema/mule/validation"
+	xmlns:ee="http://www.mulesoft.org/schema/mule/ee/core"
+	xmlns="http://www.mulesoft.org/schema/mule/core"
+	xmlns:doc="http://www.mulesoft.org/schema/mule/documentation"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.mulesoft.org/schema/mule/core http://www.mulesoft.org/schema/mule/core/current/mule.xsd
+http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/ee/core/current/mule-ee.xsd
+http://www.mulesoft.org/schema/mule/validation http://www.mulesoft.org/schema/mule/validation/current/mule-validation.xsd">
+	<flow
+		name="common-set-auth-vars-from-headers"
+		doc:id="49a5f71b-1858-485c-909a-f535468ebfb2">
+		<validation:is-true
+			doc:name="Credentials provided?"
+			doc:id="ff4ef3a2-2e1b-45ed-b4eb-7afee5cb967d"
+			expression='#[( (!isEmpty(attributes.headers."X-ANYPNT-USERNAME") and !isEmpty(attributes.headers."X-ANYPNT-PASSWORD")) or (!isEmpty(attributes.headers."X-ANYPNT-CLIENT-ID") and !isEmpty(attributes.headers."X-ANYPNT-CLIENT-SECRET")) )]' message="Anypoint username and password OR connected app clientId and clientSecret must be provided."/>
 		<ee:transform doc:name="Set Master Org Id and Auth Mode" doc:id="63cefa2c-0709-40ad-b2b0-e69e4b9a2d3d" >
-			<ee:message >
-			</ee:message>
 			<ee:variables >
 				<ee:set-variable resource="dw/common/set-master-org-id-var.dwl" variableName="masterOrgId" />
 				<ee:set-variable resource="dw/common/set-auth-mode-var.dwl" variableName="authMode" />
+				<ee:set-variable resource="dw/common/set-client-secret-var.dwl" variableName="clientSecret" />
+				<ee:set-variable resource="dw/common/set-client-id-var.dwl" variableName="clientId" />
 			</ee:variables>
 		</ee:transform>
-		<choice doc:name="Choice" doc:id="2a0f377d-08e0-4d07-ac6a-c1d20125606a" >
-			<when expression="#[attributes.headers.Authorization != null and (sizeOf(attributes.headers.Authorization) &gt; 0)]">
-				<ee:transform doc:name="Set Client Id and Client Secret from Basic Auth Header" doc:id="a865fb33-a566-49d0-90b3-5953b6ad8674" >
-					<ee:message >
-					</ee:message>
-					<ee:variables >
-						<ee:set-variable resource="dw/common/set-client-id-from-basic-auth-var.dwl" variableName="clientId" />
-						<ee:set-variable resource="dw/common/set-client-secret-from-basic-auth-var.dwl" variableName="clientSecret" />
-					</ee:variables>
-				</ee:transform>
-			</when>
-			<otherwise >
-				<ee:transform doc:name="Set Client Id and Client Secret from Individual Headers" doc:id="d8aebcdb-42fd-4159-8037-46f1765b8ccb" >
-					<ee:message >
-					</ee:message>
-					<ee:variables >
-						<ee:set-variable resource="dw/common/set-client-id-var.dwl" variableName="clientId" />
-						<ee:set-variable resource="dw/common/set-client-secret-var.dwl" variableName="clientSecret" />
-					</ee:variables>
-				</ee:transform>
-			</otherwise>
-		</choice>
 	</flow>
 	
 	<flow name="common-set-auth-vars-from-properties" doc:id="80516443-205a-40a8-a7cf-28c549d1d58a">

--- a/src/main/mule/global.xml
+++ b/src/main/mule/global.xml
@@ -13,7 +13,7 @@ http://www.mulesoft.org/schema/mule/secure-properties http://www.mulesoft.org/sc
 	<configuration-properties doc:name="Configuration properties" doc:id="da590b10-a1c1-4979-b015-102664b00221" file="properties/app-${mule.env}.yaml" />
 	<configuration-properties doc:name="Configuration properties" doc:id="31f41c53-3b9c-4d8a-8385-b799a45797b8" file="properties/app-common.yaml" />
 	<http:listener-config name="HTTP_Listener_config" doc:name="HTTP Listener config" doc:id="ef1c0e75-8dda-43df-a738-8d4ed076b92f">
-		<http:listener-connection host="0.0.0.0" port="${http.port}" />
+		<http:listener-connection host="${api.host}" port="${api.port}" />
 	</http:listener-config>
 	<ee:object-store-caching-strategy name="Caching_Strategy" doc:name="Caching Strategy" doc:id="b611514f-83b0-421a-84ae-34a1de9f18c7">
 		<os:private-object-store alias="cache-os" maxEntries="${cache.token.maxEntries}" entryTtl="${cache.token.ttl}"

--- a/src/main/mule/sources/anypoint/platform/apis/api-call-api-platform.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-api-platform.xml
@@ -85,7 +85,7 @@ output application/json
 vars.apiClientsResponsePayload]]></ee:set-payload>
 			</ee:message>
 		</ee:transform>
-		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["API Platform - Clients, Response Status Code:" ++ attributes.statusCode]' />
+		<logger level="DEBUG" doc:name="Logger" doc:id="44625425-13b2-42b6-9886-1bbbe2de07fb" message='#["API Platform - Clients, Response Status Code:" ++ (attributes.statusCode default "")]' />
 	</flow>
 
 

--- a/src/main/resources/api/api.raml
+++ b/src/main/resources/api/api.raml
@@ -1,55 +1,16 @@
 #%RAML 1.0
-baseUri: https://anypoint.mulesoft.com/mocking/api/v1/links/f724e6da-ec13-4c76-b7c7-eeaf154323e3/api/ # baseUri: https://localhost:8081/api/
 title: Metrics Accelerator API
 description: Metrics Accelerator API to obtain and generate operational and business metrics
 version: v1
 protocols: 
   - HTTPS
   
-securedBy: [basic-auth, platform-auth, connected-app-auth]
-securitySchemes:
-  basic-auth:
-    description: | 
-      This API supports Basic Authentication, and can be used only for platform user authentication 
-      This mechanism is mandatory if the password contains special characters
-      For Connected Apps authentication, connected-app-auth security scheme must be used.
-    type: Basic Authentication
-  platform-auth:
-    description: Authentication scheme for plaform users. If password contains special characters, Basic Authentication must be used.
-    displayName: Platform User Authentication Headers
-    type: x-platform-auth
-    describedBy:
-      headers:
-        X-ANYPNT-USERNAME:
-          description: |
-            Receives the username used when login to Anypoint Platform.
-          type: string
-          required: true
-        X-ANYPNT-PASSWORD:
-          description: |
-            Receives a text/plain password used when login to Anypoint Platform.
-          type: string
-          required: true
-  connected-app-auth:
-    description: Authentication scheme for connected apps.
-    displayName: Connected App Authentication Headers
-    type: x-connected-app-auth
-    describedBy:
-      headers:
-        X-ANYPNT-CLIENT-ID:
-          description: |
-            Receives the connected app client id used when login to Anypoint Platform.
-          type: string
-          required: true
-        X-ANYPNT-CLIENT-SECRET:
-          description: |
-            Receives the connected app client secret when login to Anypoint Platform.
-          type: string
-          required: true
+uses:
+  anypoint: libraries/anypoint-library.raml
+
 /platform-metrics:
+  is: [anypoint.hasHeaders]
   get:
-    headers:
-      X-ANYPNT-ORG-ID: string
     queryParameters:
       collectors:
         description: | 
@@ -86,9 +47,8 @@ securitySchemes:
         body:
           application/json:
   /load:
+    is: [anypoint.hasHeaders]
     post:
-      headers:
-        X-ANYPNT-ORG-ID: string 
       body:
         application/json:
           
@@ -99,9 +59,8 @@ securitySchemes:
               
     
 /business-metrics:
+  is: [anypoint.hasHeaders]
   get:
-    headers:
-      X-ANYPNT-ORG-ID: string
     queryParameters:
       developAPIHistoricTime:
         description: "Historic average time to develop an API (days)"
@@ -123,9 +82,8 @@ securitySchemes:
         body:
           application/json:
   /load:
+    is: [anypoint.hasHeaders]
     post:
-      headers:
-        X-ANYPNT-ORG-ID: string
       body:
         application/json:
       responses:

--- a/src/main/resources/api/libraries/anypoint-library.raml
+++ b/src/main/resources/api/libraries/anypoint-library.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0 Library
+usage: Anypoint headers for accessing platform APIs. 
+traits:
+  hasHeaders:
+    description: Headers for accessing the Anypoint Platform.  Includes authentication and org information.
+    displayName: Anypoint Platform Headers
+    headers:
+      X-ANYPNT-USERNAME:
+        description: |
+          Receives the username used to login to Anypoint Platform.
+        type: string
+        required: false
+      X-ANYPNT-PASSWORD:
+        description: |
+          Receives a plain text or Base64-encoded password used to login to Anypoint Platform.
+        type: string
+        required: false
+      X-ANYPNT-CLIENT-ID:
+        description: |
+          Receives the connected app client id used to login to Anypoint Platform.
+        type: string
+        required: false
+      X-ANYPNT-CLIENT-SECRET:
+        description: |
+          Receives the connected app client secret to login to Anypoint Platform.
+        type: string
+        required: false
+      X-ANYPNT-ORG-ID:
+        description: Anypoint root Organization ID for acquiring metrics.
+        type: string
+        required: true

--- a/src/main/resources/dw/apikit/error-bad-request.dwl
+++ b/src/main/resources/dw/apikit/error-bad-request.dwl
@@ -1,4 +1,7 @@
 %dw 2.0
 output application/json
 ---
-{message: "Bad request"}
+{
+	message: "Bad request",
+	error: error.description default ""
+}

--- a/src/main/resources/dw/common/set-client-id-from-basic-auth-var.dwl
+++ b/src/main/resources/dw/common/set-client-id-from-basic-auth-var.dwl
@@ -1,5 +1,0 @@
-%dw 2.0
-import * from dw::core::Binaries
-output application/java
----
-(fromBase64((attributes.headers.Authorization default "") replace "Basic " with "") as String splitBy ":")[0]

--- a/src/main/resources/dw/common/set-client-id-var.dwl
+++ b/src/main/resources/dw/common/set-client-id-var.dwl
@@ -1,7 +1,10 @@
 %dw 2.0
 output application/java
+
+var clientId = attributes.headers."X-ANYPNT-CLIENT-ID"
+var username = attributes.headers."X-ANYPNT-USERNAME"
 ---
-if (!isEmpty(attributes.headers."X-ANYPNT-CLIENT-ID")) 
-  attributes.headers."X-ANYPNT-CLIENT-ID" 
+if (!isEmpty(clientId)) 
+  clientId
 else 
-  attributes.headers."X-ANYPNT-USERNAME"
+  username

--- a/src/main/resources/dw/common/set-client-secret-from-basic-auth-var.dwl
+++ b/src/main/resources/dw/common/set-client-secret-from-basic-auth-var.dwl
@@ -1,5 +1,0 @@
-%dw 2.0
-import * from dw::core::Binaries
-output application/java
----
-(fromBase64((attributes.headers.Authorization default "") replace "Basic " with "") as String splitBy ":")[1]

--- a/src/main/resources/dw/common/set-client-secret-var.dwl
+++ b/src/main/resources/dw/common/set-client-secret-var.dwl
@@ -1,6 +1,15 @@
 %dw 2.0
+import * from dw::core::Binaries
 output application/java
+
+var clientSecret = attributes.headers."X-ANYPNT-CLIENT-SECRET"
+var password = attributes.headers."X-ANYPNT-PASSWORD"
+fun isBase64(text) = text matches(/^([A-Za-z0-9+]{4})*([A-Za-z0-9+]{3}=|[A-Za-z0-9+]{2}==)?$/)
+fun getSecret(secret) = if (isBase64(secret default ""))
+		fromBase64(secret) as String 
+	else secret
 ---
-if (!isEmpty(attributes.headers."X-ANYPNT-CLIENT-SECRET")) 
-  attributes.headers."X-ANYPNT-CLIENT-SECRET" 
-else attributes.headers."X-ANYPNT-PASSWORD"
+if (!isEmpty(clientSecret))
+	getSecret(clientSecret)
+else 
+	getSecret(password)

--- a/src/main/resources/properties/app-dev.yaml
+++ b/src/main/resources/properties/app-dev.yaml
@@ -1,11 +1,14 @@
-http:
+# API config
+api:
+  host: "0.0.0.0"
   port: "8081"
-  private.port: "8091"
+  path: "/api/*"
   
-https:
-  port: "8082"
-  private.port: "8092"
-  
+# Dashboard config
+embedded.dashboard:
+  path: "/*"
+  enabled: "false"
+
 poller:
   enabled: "false"
   frequency: 
@@ -51,9 +54,6 @@ loader:
 # Default value: "all"
   
 collectors: "all"
-
-embedded.dashboard:
-  enabled: "false"
   
 splunk:
   host: "splunk-metrics.env.services.mulesoft.com"

--- a/src/test/munit/unit-test-loader-platform-benefits-router.xml
+++ b/src/test/munit/unit-test-loader-platform-benefits-router.xml
@@ -139,8 +139,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="e93b7267-c275-46c2-aad4-73fed5a37fa4"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="e93b7267-c275-46c2-aad4-73fed5a37fa4"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="f2ed5b29-3fbb-4727-beba-c77afde83147"
@@ -168,8 +168,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="3bc789ce-31f4-4961-aff6-8c9afe4c77fb"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="3bc789ce-31f4-4961-aff6-8c9afe4c77fb"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="d0bcb808-ebd0-4b32-a599-6bf00a2a0a54"
@@ -197,8 +197,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="9011c624-e50f-4442-a62f-43148380ad48"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="9011c624-e50f-4442-a62f-43148380ad48"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="bc162980-9851-458b-9d00-24b756ade97d"
@@ -226,8 +226,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="d16184c0-89a4-4588-8273-97e38535c092"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="d16184c0-89a4-4588-8273-97e38535c092"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="d0f2593f-d3ee-4c2d-9e74-0946f7b3406a"
@@ -255,8 +255,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="b92eaa97-8b5c-4649-bc5a-cbaab2b75048"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="b92eaa97-8b5c-4649-bc5a-cbaab2b75048"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="9eff5880-49f8-4d4e-9cca-703d8262a51d"
@@ -272,8 +272,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="e3f8d868-0aff-46a3-9592-f1bddb0c6ede"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="e3f8d868-0aff-46a3-9592-f1bddb0c6ede"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="4cdfa84b-22bc-4215-97b0-179f947ac049"
@@ -292,8 +292,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="04553740-21d5-4527-a191-967070e916a7"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="04553740-21d5-4527-a191-967070e916a7"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="653b70de-6290-484f-a571-10f0477a4a2f"
@@ -314,8 +314,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="3b9c510e-266e-4516-9c1f-5d2c59e81ff1"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="3b9c510e-266e-4516-9c1f-5d2c59e81ff1"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 		<munit:validation>
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="a6b8b3f1-aa58-4984-a58b-47ef54dff2aa"
@@ -333,8 +333,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:api-config" doc:id="0483dd77-72c6-45c9-b1af-53195755df01"
-				name="post:\business-metrics\load:api-config" />
+			<flow-ref doc:name="Flow-ref to post:\business-metrics\load:application\json:api-config" doc:id="0483dd77-72c6-45c9-b1af-53195755df01"
+				name="post:\business-metrics\load:application\json:api-config" />
 		</munit:execution>
 	</munit:test>
 </mule>

--- a/src/test/munit/unit-test-loader-platform-metrics-router.xml
+++ b/src/test/munit/unit-test-loader-platform-metrics-router.xml
@@ -335,7 +335,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="7fc11a37-43af-46d3-a46f-231b1b03b006" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="7fc11a37-43af-46d3-a46f-231b1b03b006" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="6c6a3cb3-518c-41fd-934f-e058e1289ce0" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -360,7 +360,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="2821023b-42ef-4be5-87be-81b6b2643a4e" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="2821023b-42ef-4be5-87be-81b6b2643a4e" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="9d88244c-7fbd-4a51-ae98-e725044e3d67" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -385,7 +385,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="d4555c2d-c0cc-4971-8a06-f5616a3cf1fa" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="d4555c2d-c0cc-4971-8a06-f5616a3cf1fa" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="f0a60f4a-3630-482d-bc12-f16621b02623" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -410,7 +410,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="3cd861c3-99f5-43e5-8eac-38f1304e0ef6" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="3cd861c3-99f5-43e5-8eac-38f1304e0ef6" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="843348bb-47d3-4da8-8735-5a60eaa41ae6" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -435,7 +435,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="e1ae5bd9-983e-4933-b278-1d26684e2783" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="e1ae5bd9-983e-4933-b278-1d26684e2783" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="a878b43b-b192-414e-9142-fb755d3e8c74" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -450,7 +450,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="457877c3-9ba0-4bc9-a01d-c1742de6042e" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="457877c3-9ba0-4bc9-a01d-c1742de6042e" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="8d909d8c-0e76-41af-9868-d29546e153f5" expression='#[payload]' is="#[MunitTools::equalTo(vars.expectedResponse)]" message="The response payload is not the expected" />
@@ -466,7 +466,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="3e3ea9b2-5cfc-421d-aafb-6236b6117af2" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="3e3ea9b2-5cfc-421d-aafb-6236b6117af2" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="a906bf55-616a-4015-bc48-ba7b5a48563b" expression='#[payload map ($ - "date")]' is='#[MunitTools::equalTo(vars.expectedCsvResponse map ($ - "date"))]' message="The response payload is not the expected" />
@@ -482,7 +482,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="d553356e-73a1-4182-9d94-c6450871aea2" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="d553356e-73a1-4182-9d94-c6450871aea2" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="308936d6-f3e4-4801-b79f-1bac9c934cd0" expression='#[payload map ($ - "date")]' is='#[MunitTools::equalTo(vars.expectedJsonResponse map ($ - "date"))]' message="The response payload is not the expected" />
@@ -497,7 +497,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-attributes resource="dw/mock-call-attributes.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:api-config" doc:id="ffab454f-41b3-486e-a011-4b633ff507dc" name="post:\platform-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\platform-metrics\load:application\json:api-config" doc:id="ffab454f-41b3-486e-a011-4b633ff507dc" name="post:\platform-metrics\load:application\json:api-config"/>
 		</munit:execution>
 	</munit:test>
 </mule>

--- a/src/test/munit/unit-test-loader-sdlc-router.xml
+++ b/src/test/munit/unit-test-loader-sdlc-router.xml
@@ -32,7 +32,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-am.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="e93b7267-c275-46c2-aad4-73fed5a37fa4" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="e93b7267-c275-46c2-aad4-73fed5a37fa4" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="f2ed5b29-3fbb-4727-beba-c77afde83147" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -56,7 +56,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-splunk.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="3bc789ce-31f4-4961-aff6-8c9afe4c77fb" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="3bc789ce-31f4-4961-aff6-8c9afe4c77fb" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="d0bcb808-ebd0-4b32-a599-6bf00a2a0a54" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -80,7 +80,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-splunk-https.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="9011c624-e50f-4442-a62f-43148380ad48" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="9011c624-e50f-4442-a62f-43148380ad48" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="bc162980-9851-458b-9d00-24b756ade97d" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -104,7 +104,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-elk.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="d16184c0-89a4-4588-8273-97e38535c092" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="d16184c0-89a4-4588-8273-97e38535c092" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="d0f2593f-d3ee-4c2d-9e74-0946f7b3406a" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -128,7 +128,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-tableau.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="b92eaa97-8b5c-4649-bc5a-cbaab2b75048" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="b92eaa97-8b5c-4649-bc5a-cbaab2b75048" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="9eff5880-49f8-4d4e-9cca-703d8262a51d" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -142,7 +142,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-logger.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="e3f8d868-0aff-46a3-9592-f1bddb0c6ede" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="e3f8d868-0aff-46a3-9592-f1bddb0c6ede" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="4cdfa84b-22bc-4215-97b0-179f947ac049" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -156,7 +156,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-csv.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="04553740-21d5-4527-a191-967070e916a7" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="04553740-21d5-4527-a191-967070e916a7" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="653b70de-6290-484f-a571-10f0477a4a2f" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -170,7 +170,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-json.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="3b9c510e-266e-4516-9c1f-5d2c59e81ff1" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="3b9c510e-266e-4516-9c1f-5d2c59e81ff1" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="a6b8b3f1-aa58-4984-a58b-47ef54dff2aa" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />
@@ -184,7 +184,7 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 					<ee:set-payload resource="dw/mock-loader-strategy-payload-mongodb.dwl" />
 				</ee:message>
 			</ee:transform>
-			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:api-config" doc:id="1df10218-7982-428e-b7c7-885c06209830" name="post:\sdlc-metrics\load:api-config"/>
+			<flow-ref doc:name="Flow-ref to post:\sdlc-metrics\load:application\json:api-config" doc:id="1df10218-7982-428e-b7c7-885c06209830" name="post:\sdlc-metrics\load:application\json:api-config"/>
 		</munit:execution>
 		<munit:validation >
 			<munit-tools:assert-that doc:name="Assert Expected Response" doc:id="936c130f-9f29-4e1f-b8b8-bb4d8b369245" expression='#[payload]' is='#[MunitTools::equalTo(vars.expectedResponse)]' message="The response payload is not the expected" />


### PR DESCRIPTION
Features
- api.raml: moved anypoint headers to library and removed from securedBy.  The headers are the Anypoint Platform securty, NOT necessarily the security for this API.  Keeping them out of the Authorization header allows for implementers to use their own security such as OAuth.  The Anypoint security must still be provided in addition to any security added by the implementer.
- Added feature to allow Base64 or plain text secrets in both secret/password anypoint headers.
- Added API and Dashboard HTTP values as properties in app-dev.yaml.
- Added loggers to dashboard choices.  Added 501-Not Implemented if dashboard is disabled.
Fixes
- Fixed api.xml flow names to match api.raml for POST.  Auto-generated flow names were different.
- Updated latest version of dependencies
- api-call-api-platform: Added default empty string to avoid null error when no response code provided.