### PR TITLE
Added accept header to analytics API query to ensure JSON response

### DIFF
--- a/src/main/mule/sources/anypoint/platform/apis/api-call-analytics.xml
+++ b/src/main/mule/sources/anypoint/platform/apis/api-call-analytics.xml
@@ -44,7 +44,8 @@ http://www.mulesoft.org/schema/mule/ee/core http://www.mulesoft.org/schema/mule/
 			<http:headers><![CDATA[#[output application/java
 ---
 {
-	"Authorization" : "Bearer " ++ vars.token
+	"Authorization" : "Bearer " ++ vars.token,
+	"Accept" : "application/json"
 }]]]></http:headers>
 			<http:uri-params><![CDATA[#[output application/java
 ---


### PR DESCRIPTION
Without an Accept header the API sometimes returns response in plain text, breaking subsequent transformations. Added header Accept="application/json" to resolve this 